### PR TITLE
This PR adds server reflection capability

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>grpc-stub</artifactId>
             <version>1.49.2</version>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-services</artifactId>
+            <version>1.49.2</version>
+        </dependency>
 
         <dependency>
             <groupId>commons-codec</groupId>

--- a/auth/src/main/java/org/example/authserver/Application.java
+++ b/auth/src/main/java/org/example/authserver/Application.java
@@ -12,6 +12,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import io.grpc.protobuf.services.ProtoReflectionService;
 
 @Slf4j
 @EnableConfigurationProperties
@@ -37,7 +38,9 @@ public class Application {
   public void start() throws Exception {
     cacheLoaderService.subscribe();
 
-    Server server = ServerBuilder.forPort(grpcPort).addService(authService).build();
+    Server server = ServerBuilder.forPort(grpcPort)
+        .addService(ProtoReflectionService.newInstance())
+        .addService(authService).build();
 
     server.start();
     log.info("Started. Listen GRPC port: {}}", grpcPort);


### PR DESCRIPTION
This PR adds [server reflection capability](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) to auth service. With this change, we can use grpcurl to invoke the auth service
```sh
grpcurl -d '{"attributes": {"request": { "http": {"method": "GET"} }}}' -plaintext localhost:8182 envoy.service.auth.v3.Authorization/Check
{
  "status": {
    "code": 7
  },
  "ok_response": {
    "headers": [
      {
        "header": {
          "key": "X-ALLOWED-TAGS"
        }
      }
    ]
  }
}
```
This will be very useful for debugging